### PR TITLE
Don't fail building when there is .babelrc file.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,13 @@
+# 0.27.0 / 2020-10-20
+- Don't fail building when there is .babelrc file. Instead, use .babelrc.build for the temporary config.
+
+  [Babel CLI](https://babeljs.io/docs/en/babel-cli#custom-config-path) allows for `--config-file` option with which you can specify your own config file. Thanks to that, if there is already .babelrc file in the repo, the build can still continue instead of being stopped.
+
 # 0.26.0 / 2020-10-20
 ## Fixes
 - Allow to specify Babel CLI extensions argument. This makes it possible to compile Typescript components.
 
+# MISSING
 ## Dependencies
 
 - @babel/cli: v7.8.4 → [v7.10.3](https://github.com/babel/babel/blob/master/CHANGELOG.md#v7102-2020-05-30)

--- a/src/moduleBuild.js
+++ b/src/moduleBuild.js
@@ -10,7 +10,6 @@ import cleanModule from './commands/clean-module'
 import {getPluginConfig, getUserConfig} from './config'
 import createBabelConfig from './createBabelConfig'
 import debug from './debug'
-import {UserError} from './errors'
 import {deepToString, formatPackageName} from './utils'
 import webpackBuild from './webpackBuild'
 import {createBanner, createExternals, logGzippedFileSizes} from './webpackUtils'
@@ -23,10 +22,12 @@ const DEFAULT_BABEL_IGNORE_CONFIG = [
   '**/__tests__/'
 ]
 
+const DEFAULT_BABEL_CONFIG_FILE = '.babelrc'
+
 /**
  * Run Babel with generated config written to a temporary .babelrc.
  */
-function runBabel(name, {copyFiles, outDir, src, extensions}, buildBabelConfig, userConfig, cb) {
+function runBabel(name, {copyFiles, outDir, src, extensions, configFileName}, buildBabelConfig, userConfig, cb) {
   let babelConfig = createBabelConfig(buildBabelConfig, userConfig.babel, userConfig.path)
   babelConfig.ignore = DEFAULT_BABEL_IGNORE_CONFIG
 
@@ -39,6 +40,10 @@ function runBabel(name, {copyFiles, outDir, src, extensions}, buildBabelConfig, 
 
   if (extensions) {
     args.push('--extensions', extensions)
+  }
+
+  if (configFileName !== DEFAULT_BABEL_CONFIG_FILE) {
+    args.push('--config-file', path.resolve(configFileName))
   }
 
   fs.writeFile('.babelrc', JSON.stringify(babelConfig, null, 2), (err) => {
@@ -54,7 +59,7 @@ function runBabel(name, {copyFiles, outDir, src, extensions}, buildBabelConfig, 
       else {
         spinner.succeed()
       }
-      fs.unlink('.babelrc', (unlinkError) => {
+      fs.unlink(configFileName, (unlinkError) => {
         cb(babelError || unlinkError)
       })
     })
@@ -118,12 +123,16 @@ function buildUMD(args, buildConfig, userConfig, cb) {
 }
 
 export default function moduleBuild(args, buildConfig = {}, cb) {
-  // XXX Babel doesn't support passing the path to a babelrc file any more
-  if (fs.existsSync('.babelrc')) {
-    throw new UserError(
-      'Unable to build the module as there is a .babelrc in your project\n' +
-      'nwb needs to write a temporary .babelrc to configure the build'
+  let configFileName = DEFAULT_BABEL_CONFIG_FILE
+
+  if (fs.existsSync(configFileName)) {
+    console.info(
+      `There is a ${configFileName} in your project ` +
+      `nwb needs to write a temporary ${configFileName} to configure the build, ` +
+      `will use ${configFileName}.build instead`
     )
+
+    configFileName += '.build'
   }
 
   if (!process.env.NODE_ENV) {
@@ -136,6 +145,7 @@ export default function moduleBuild(args, buildConfig = {}, cb) {
     copyFiles: !!args['copy-files'],
     src: path.resolve('src'),
     extensions: args['extensions'] || args['x'],
+    configFileName
   }
 
   let tasks = [(cb) => cleanModule(args, cb)]


### PR DESCRIPTION
Instead, use .babelrc.build for the temporary config.
Babel CLI v7 allows for --config-file option with which you can specify
your own config file. Thanks to that, if there is already .babelrc file
in the repo, the build can still continue instead of being stopped.

ref: https://babeljs.io/docs/en/babel-cli#custom-config-path
